### PR TITLE
README.md: add nscd, console-setup to deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo apt-get install build-essential devscripts debhelper cmake libldap2-dev lib
 If not using a Pi (or other armhf device), you also need the following runtime dependencies:
 
 ```
-sudo apt-get install binfmt-support qemu-user-static
+sudo apt-get install binfmt-support qemu-user-static console-setup nscd
 ```
 
 


### PR DESCRIPTION
Piserver will run on non-Raspbian platforms without these, but will fail when
installing software on the server during Pi configuration.