### PR TITLE
Remove improper references to gksu

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Raspberry Pi Server wizard to serve Raspbian to network booting Pis
 On Raspbian install the build dependencies:
 
 ```
-sudo apt-get install build-essential devscripts debhelper cmake libldap2-dev libgtkmm-3.0-dev libarchive-dev libcurl4-openssl-dev intltool gksu git
+sudo apt-get install build-essential devscripts debhelper cmake libldap2-dev libgtkmm-3.0-dev libarchive-dev libcurl4-openssl-dev intltool git
 ```
 
 If not using a Pi (or other armhf device), you also need the following runtime dependencies:

--- a/data/piserver.desktop.in
+++ b/data/piserver.desktop.in
@@ -4,5 +4,5 @@ Version=1.0
 _Name=PiServer
 _Comment=Server for diskless Pi 3
 Icon=folder-remote
-Exec=gksudo piserver
+Exec=sh -c "sudo piserver || pkexec piserver"
 Categories=Settings


### PR DESCRIPTION
A previous merge removed gksu, but it wasn't removed from the installation instructions or one of the .desktop files.