### PR TITLE
Update convert scripts for Bullseye and arm64

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -6,78 +6,77 @@
 set -e
 
 if [ $# -ne 3 ]; then
-    echo $0: script to convert boot.tar.xz/root.tar.xz to image suitable for PiServer
+    echo "$0: script to convert boot.tar.xz/root.tar.xz to image suitable for PiServer"
     echo
-    echo Usage: $0 boot.tar.xz root.tar.xz output.tar.xz
+    echo "Usage: $0 boot.tar.xz root.tar.xz output.tar.xz"
     exit 1
 fi
 
-BOOT_TARBALL=$1
-ROOT_TARBALL=$2
-OUTPUT_TARBALL=$3
+BOOT_TARBALL="$1"
+ROOT_TARBALL="$2"
+OUTPUT_TARBALL="$3"
 ARCH=$(dpkg --print-architecture)
-CHROOT_SCRIPT=`dirname $0`/convert_chrooted_cmds
+CHROOT_SCRIPT=$(dirname "$0")/convert_chrooted_cmds
 
 if [ -d work ]; then
-    echo There already exists a temporary folder called 'work'
-    echo Aborting.
-    echo If a previous session was aborted, delete the folder manually
+    echo "There already exists a temporary folder called 'work'"
+    echo "Aborting."
+    echo "If a previous session was aborted, delete the folder manually"
     exit 1
 fi
 
 if [ ! -f "$ROOT_TARBALL" ]; then
-    echo $ROOT_TARBALL does not exists
+    echo "$ROOT_TARBALL does not exists"
     exit 1
 fi
 
 if [ ! -f "$BOOT_TARBALL" ]; then
-    echo $BOOT_TARBALL does not exists
+    echo "$BOOT_TARBALL does not exists"
     exit 1
 fi
 
 if [ "$EUID" -ne 0 ]; then
-    echo Script needs to be run as root
+    echo "Script needs to be run as root"
     exit 1
 fi
 
-if [ "$ARCH" != "armhf" ]; then
+if [[ "$ARCH" != arm* ]]; then
     command -v qemu-arm-static > /dev/null || { echo "qemu-arm-static command not found. Try: sudo apt-get install binfmt-support qemu-user-static"; exit 1; }
 fi
 command -v xz > /dev/null || { echo "xz command not found. Try: sudo apt install xz"; exit 1; }
 
 mkdir work
-echo Extracting original files
-tar xJf $ROOT_TARBALL -C work 
-tar xJf $BOOT_TARBALL -C work/boot 
+echo "Extracting original files"
+tar xJf "$ROOT_TARBALL" -C work
+tar xJf "$BOOT_TARBALL" -C work/boot
+
+if ! chroot work true; then
+    echo "Could not chroot into target environment. Please make sure binfmt is set up properly"
+    echo "Deleting work directory"
+    rm -rf work
+    exit 1
+fi
 
 install -m 0755 "$CHROOT_SCRIPT" work/chrooted_cmds
-mv work/etc/ld.so.preload work/etc/ld.so.preload.disabled
 modprobe fuse
 
-echo Installing extra software
+echo "Installing extra software"
 
 mount -t proc none work/proc
 
-if [ "$ARCH" == "armhf" ]; then
-    chroot work /bin/bash /chrooted_cmds
-else
-    install -m 0755 /usr/bin/qemu-arm-static work/usr/bin/qemu-arm-static
-    chroot work qemu-arm-static /bin/bash /chrooted_cmds
-fi
+chroot work /chrooted_cmds
 
 umount work/proc
 
 rm -f work/chrooted_cmds
-rm -f work/usr/bin/qemu-arm-static
-mv work/etc/ld.so.preload.disabled work/etc/ld.so.preload
 rm -rf work/run/*
 
-echo Compressing result
-tar cf $OUTPUT_TARBALL -C work --use-compress-program "xz -T0" .
-echo Deleting work directory
+echo "Compressing result"
+tar cf "$OUTPUT_TARBALL" -C work --use-compress-program "xz -T0" .
+echo "Deleting work directory"
 rm -rf work
 
 echo
 echo Complete!
-echo Output is in $OUTPUT_TARBALL
+echo "Output is in $OUTPUT_TARBALL"
 echo

--- a/scripts/convert_chrooted_cmds
+++ b/scripts/convert_chrooted_cmds
@@ -15,7 +15,7 @@ tmpfs           /var/tmp        tmpfs   defaults,nosuid,nodev,noexec 0       0
 tmpfs           /var/log        tmpfs   defaults,mode=755,size=100m  0       0
 tmpfs           /var/spool      tmpfs   defaults,mode=755            0       0
 tmpfs           /var/lib/sudo   tmpfs   defaults,mode=711            0       0
-tmpfs           /var/lib/dhcp   tmpfs   defaults,mode=755            0       0
+tmpfs           /var/lib/dhcpcd tmpfs   defaults,mode=755            0       0
 tmpfs           /var/lib/systemd/rfkill   tmpfs defaults,mode=755    0       0
 tmpfs           /var/lib/systemd/coredump tmpfs defaults,mode=755    0       0
 tmpfs           /var/lib/systemd/timesync tmpfs defaults,mode=755    0       0
@@ -32,7 +32,7 @@ if [ -d /var/cache ]; then
 fi
 
 if [ -d /var/lib/lightdm ]; then
-    echo "tmpfs           /var/lib/lightdm  tmpfs defaults,mode=755,nosuid     0       0" >> /etc/fstab
+    echo "tmpfs           /var/lib/lightdm  tmpfs defaults,uid=lightdm,gid=lightdm,mode=755,nosuid     0       0" >> /etc/fstab
 fi
 
 debconf-set-selections <<EOF
@@ -82,6 +82,12 @@ if grep -qv disable_interactive /etc/pam.d/common-password; then
     echo "password  optional  pam_mount.so disable_interactive" >> /etc/pam.d/common-password
 fi
 
+# Disable user rename
+cancel-rename pi
+userdel -r rpi-first-boot-wizard
+rm -f /etc/sudoers.d/010_wiz-nopasswd
+rm -f /etc/xdg/autostart/deluser.desktop
+
 if [ -f /etc/lightdm/lightdm.conf ]; then
     # Disable GUI auto-login
     sed -i "s/^autologin-user=.*/#autologin-user=/" /etc/lightdm/lightdm.conf
@@ -96,7 +102,7 @@ ln -fs /lib/systemd/system/getty@.service /etc/systemd/system/getty.target.wants
 rm -f /etc/systemd/system/getty@tty1.service.d/autologin.conf
 
 # No point in saving random seed on read-only system
-rm -f $DISTROROOT/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service
+rm -f "$DISTROROOT"/lib/systemd/system/sysinit.target.wants/systemd-random-seed.service
 
 # systemd-tmpfiles-setup should not try to change files on read-only file system
 rm -f /usr/lib/tmpfiles.d/dbus.conf /usr/lib/tmpfiles.d/debian.conf
@@ -121,9 +127,11 @@ fi
 # dhcpcd: disable link detection as we do not want dhcpcd to tear down interface if cable gets disconnected temporarily
 if [ -f /etc/dhcpcd.conf ]; then
     echo "nolink" >> /etc/dhcpcd.conf
-    echo "# Piserver: disable wifi by default" >> /boot/config.txt
-    echo "# If you have a need for wifi, remove both the following line, as well as nolink from /etc/dhcpcd.conf" >> /boot/config.txt
-    echo "dtoverlay=disable-wifi" >> /boot/config.txt
+    {
+        echo "# Piserver: disable wifi by default"
+        echo "# If you have a need for wifi, remove both the following line, as well as nolink from /etc/dhcpcd.conf"
+        echo "dtoverlay=disable-wifi"
+    } >> /boot/config.txt
 fi
 
 # do not continously poll for SD card
@@ -136,14 +144,16 @@ sed -i 's# init=/usr/lib/raspi-config/init_resize.sh##g' /boot/cmdline.txt
 sed -i 's# fsck.repair=yes##g' /boot/cmdline.txt
 sed -i 's# rootfstype=ext4##g' /boot/cmdline.txt
 
-# Disable swap
-rm -f /lib/systemd/system/dphys-swapfile.service
+# Remove dphys-swapfile and logrotate
+apt-get purge -y -q dphys-swapfile logrotate
 
 # Default to disabling per-user browser disk cache
 if [ -e /etc/chromium.d ]; then
+     # shellcheck disable=SC2016
     echo 'export CHROMIUM_FLAGS="$CHROMIUM_FLAGS --disk-cache-dir=/dev/null --disk-cache-size=1"' >/etc/chromium.d/99-piserver-disable-cache
 fi
 if [ -e /etc/chromium-browser/customizations ]; then
+    # shellcheck disable=SC2016
     echo 'CHROMIUM_FLAGS="$CHROMIUM_FLAGS --disk-cache-dir=/dev/null --disk-cache-size=1"' >/etc/chromium-browser/customizations/99-piserver-disable-cache
 fi
 
@@ -173,7 +183,9 @@ delgroup pi
 # Make all users part of some extra local groups when logged in through lightdm
 #
 sed -i '/@include common-auth/a auth       optional   pam_group.so' /etc/pam.d/lightdm
-echo "" >> /etc/security/group.conf
-echo "# Added for Piserver" >> /etc/security/group.conf
-echo "lightdm;*;*;Al0000-2400;dialout, audio, video, spi, i2c, gpio, plugdev, input" >> /etc/security/group.conf
+{
+    echo
+    echo "# Added for Piserver"
+    echo "lightdm;*;*;Al0000-2400;dialout, audio, video, spi, i2c, gpio, plugdev, input"
+} >> /etc/security/group.conf
 #echo "login;tty*;*;Al0000-2400;dialout, spi, i2c, gpio" >> /etc/security/group.conf


### PR DESCRIPTION
Nowadays qemu-user-static sets up binfmt with the `F` flag, which removes the need to copy the binary into the chroot

`/etc/ld.so.preload` shouldn't be needed anymore

Set `/var/lib/lightdm` ownership to `lightdm` to squelch errors from pulseaudio

Mount `/var/lib/dhcpcd` instead of `/var/lib/dhcp`. This seems to squelch some errors from `dhcpcd` without causing new ones.

Remove dphys-swapfile and logrotate entirely

Don't require qemu on arm64

Check chroot works

Minor formatting changes and shellcheck warning fixes

